### PR TITLE
Add the OverKillDamage unit value

### DIFF
--- a/XComGame/Classes/XComGameState_Unit.uc
+++ b/XComGame/Classes/XComGameState_Unit.uc
@@ -6476,6 +6476,9 @@ event TakeDamage( XComGameState NewGameState, const int DamageAmount, const int 
 	SetUnitFloatValue('LastOverkillDamage', max(-OverkillDamage,0), eCleanup_BeginTactical);
 	if (OverkillDamage <= 0)
 	{
+		// Issue #805
+		SetOverKillUnitValue(OverkillDamage);
+
 		bKilledByExplosion = bExplosiveDamage;
 		KilledByDamageTypes = DamageTypes;
 
@@ -14697,6 +14700,20 @@ function EventListenerReturn OnGeneratedCoverRemoved(Object EventData, Object Ev
 
 	return ELR_NoInterrupt;
 }
+
+
+//Begin Issue #805
+/// HL-Docs: feature:OverKillDamage; issue:805; tags:tactical
+/// The UnitState's damage results array only holds the actual damage taken by the unit, so the result can't be higher than the unit's HP.
+/// This adds the OverkillDamage Unit value, which is shows how higher the kill damage value was from the standard Unit HP.
+///	One of its use cases is to modify the effects of the abilities that trigger on death, like the trigger chance on Advent Priest's Sustain.
+/// The OverKillDamage calculated by XCGS_Unit is negative, but the unit value is set to be positive to make using it more intuitive.
+/// The value uses `eCleanup_BeginTactical`.
+private function SetOverKillUnitValue(int OverKillDamage)
+{
+	SetUnitFloatValue('OverKillDamage', -OverkillDamage, eCleanup_BeginTactical);
+}
+//	End issue #805
 
 //---------------------------------------------------------------------------------------
 //				TRAINING


### PR DESCRIPTION
Port of WOTC highlander Issue #805
Adds a Unit Value that allows Abilities to work with Overkill Damage.
Use case is to have the chance for a Priest (in CS i want to give it to sorcerer) to enter Sustain reduced by the amount of overkill damage.

