### PR TITLE
Add hook to allow mods to override hit chance

### DIFF
--- a/XComGame/Classes/X2AbilityToHitCalc.uc
+++ b/XComGame/Classes/X2AbilityToHitCalc.uc
@@ -1,0 +1,167 @@
+//---------------------------------------------------------------------------------------
+//  FILE:    X2AbilityToHitCalc.uc
+//  AUTHOR:  Joshua Bouscher
+//           
+//---------------------------------------------------------------------------------------
+//  Copyright (c) 2016 Firaxis Games, Inc. All rights reserved.
+//---------------------------------------------------------------------------------------
+class X2AbilityToHitCalc extends Object
+	abstract
+	editinlinenew
+	hidecategories(Object);
+
+var() array<ShotModifierInfo> HitModifiers;       // Configured in the ability template to provide always-on modifiers.
+
+// Start Issue #555
+//
+// Mods can add their own matching functions to this array within
+// OnPostTemplatesCreated() in order to modify or override the default
+// logic within FinalizeHitChance(). As an example, Long War of the Chosen
+// adds its own function to implement the graze band mechanic.
+//
+// Delegate functions should return `true` if they want to override the
+// default logic, or false if the logic should execute.
+var array< delegate<OverrideFinalHitChance> > OverrideFinalHitChanceFns;
+
+
+function RollForAbilityHit(XComGameState_Ability kAbility, AvailableTarget kTarget, out AbilityResultContext ResultContext);
+protected function int GetHitChance(XComGameState_Ability kAbility, AvailableTarget kTarget, optional out ShotBreakdown m_ShotBreakdown, optional bool bDebugLog=false);
+function bool NoGameStateOnMiss() { return false; }
+
+function AddHitModifier(const int ModValue, const string ModReason, optional EAbilityHitResult ModType=eHit_Success)
+{
+	local ShotModifierInfo Mod;
+	Mod.Value = ModValue;
+	Mod.Reason = ModReason;
+	Mod.ModType = ModType;
+	HitModifiers.AddItem(Mod);
+}
+
+function int GetShotBreakdown(XComGameState_Ability kAbility, AvailableTarget kTarget, optional out ShotBreakdown m_ShotBreakdown, optional bool bDebugLog = false)
+{
+	GetHitChance(kAbility, kTarget, m_ShotBreakdown, bDebugLog);
+	return m_ShotBreakdown.FinalHitChance;
+}
+
+//  Inside of GetHitChance, m_ShotBreakdown should be initially reset, then all modifiers to the shot should be added via this function.
+protected function AddModifier(const int ModValue, const string ModReason, out ShotBreakdown m_ShotBreakdown, EAbilityHitResult ModType=eHit_Success, bool bDebugLog = false, bool bShowEvenIfZero = false)
+{
+	local ShotModifierInfo Mod;
+
+	switch(ModType)
+	{
+	case eHit_Miss:
+		//  Miss should never be modified, only Success
+		`assert(false);
+		return;
+	}
+
+	if (ModValue != 0 || bShowEvenIfZero)
+	{
+		Mod.ModType = ModType;
+		Mod.Value = ModValue;
+		Mod.Reason = ModReason;
+		m_ShotBreakdown.Modifiers.AddItem(Mod);
+		m_ShotBreakdown.ResultTable[ModType] += ModValue;
+		m_ShotBreakdown.FinalHitChance = m_ShotBreakdown.ResultTable[eHit_Success];
+	}
+	`log("Modifying" @ ModType @ (ModValue >= 0 ? "+" : "") $ ModValue @ "(" $ ModReason $ "), New hit chance:" @ m_ShotBreakdown.FinalHitChance, bDebugLog, 'XCom_HitRolls');
+}
+
+protected function FinalizeHitChance(out ShotBreakdown m_ShotBreakdown, bool bDebugLog = false)
+{
+	local int i;
+	local EAbilityHitResult HitResult;
+	local float GrazeScale;
+	local int FinalGraze;
+	local int LuckyGraze;
+	local int MissToLuckyGraze;
+
+    // Vars for Issue #555
+	local bool OverrideHitChanceCalc;
+	local delegate<OverrideFinalHitChance> OverrideFn;
+	// End Issue #555
+
+    // Start Issue #555
+    OverrideHitChanceCalc = false;
+	foreach OverrideFinalHitChanceFns(OverrideFn)
+	{
+		OverrideHitChanceCalc = OverrideHitChanceCalc || OverrideFn(self, m_ShotBreakdown);
+	}
+
+	// If any of the delegate functions returns true, then we skip the default
+	// processing of the hit chance.
+	if (OverrideHitChanceCalc)
+	{
+		return;
+	}
+    // End Issue #555
+
+	`log("==" $ GetFuncName() $ "==\n", bDebugLog, 'XCom_HitRolls');
+	`log("Starting values...", bDebugLog, 'XCom_HitRolls');
+	for (i = 0; i < eHit_MAX; ++i)
+	{
+		HitResult = EAbilityHitResult(i);
+		`log(HitResult $ ":" @ m_ShotBreakdown.ResultTable[i], bDebugLog, 'XCom_HitRolls');
+	}
+
+	m_ShotBreakdown.FinalHitChance = m_ShotBreakdown.ResultTable[eHit_Success];
+	//  if crit goes negative, hit would get a boost, so restrict it to 0
+	if (m_ShotBreakdown.ResultTable[eHit_Crit] < 0)
+		m_ShotBreakdown.ResultTable[eHit_Crit] = 0;
+	//  cap success at 100 so it can be fully overridden by crit
+	m_ShotBreakdown.ResultTable[eHit_Success] = min(m_ShotBreakdown.ResultTable[eHit_Success], 100);
+	//  Crit is folded into the chance to hit, so lower accordingly
+	m_ShotBreakdown.ResultTable[eHit_Success] -= m_ShotBreakdown.ResultTable[eHit_Crit];
+	//  Graze is scaled against Success - but ignored if success is 100%
+	if (m_ShotBreakdown.ResultTable[eHit_Graze] > 0) 
+	{
+		if (m_ShotBreakdown.FinalHitChance < 100)
+		{
+			GrazeScale = float(m_ShotBreakdown.ResultTable[eHit_Graze]) / 100.0f;
+			GrazeScale *= float(m_ShotBreakdown.FinalHitChance);
+			FinalGraze = Round(GrazeScale);
+			m_ShotBreakdown.ResultTable[eHit_Success] -= FinalGraze;
+			m_ShotBreakdown.ResultTable[eHit_Graze] = FinalGraze;
+		}
+		else
+		{
+			m_ShotBreakdown.ResultTable[eHit_Graze] = 0;
+		}
+	}
+
+	if (m_ShotBreakdown.FinalHitChance >= 100)
+	{
+		m_ShotBreakdown.ResultTable[eHit_Miss] = 0;
+	}
+	else
+	{
+		// shots have a chance to graze based on shooter's luck
+		LuckyGraze = m_ShotBreakdown.ResultTable[eHit_LuckyGraze];
+		if (LuckyGraze > 0) // && m_ShotBreakdown.FinalHitChance > 50
+		{
+			MissToLuckyGraze = min(LuckyGraze, max(100 - m_ShotBreakdown.FinalHitChance, 0));
+			m_ShotBreakdown.ResultTable[eHit_LuckyGraze] = MissToLuckyGraze;
+			m_ShotBreakdown.ResultTable[eHit_Miss] = max(100 - m_ShotBreakdown.FinalHitChance - MissToLuckyGraze, 0);
+		}
+		else
+		{
+			m_ShotBreakdown.ResultTable[eHit_Miss] = 100 - m_ShotBreakdown.FinalHitChance;
+		}
+	}
+	
+	`log("Calculated values...", bDebugLog, 'XCom_HitRolls');
+	for (i = 0; i < eHit_MAX; ++i)
+	{
+		HitResult = EAbilityHitResult(i);
+		`log(HitResult $ ":" @ m_ShotBreakdown.ResultTable[i], bDebugLog, 'XCom_HitRolls');
+	}
+	`log("Final hit chance (success + crit + graze) =" @ m_ShotBreakdown.FinalHitChance, bDebugLog, 'XCom_HitRolls');
+
+	//"Negative chance to hit" is used as a token in UI code - don't ever report that.
+	if (m_ShotBreakdown.FinalHitChance < 0)
+	{
+		`log("FinalHitChance was less than 0 (" $ m_ShotBreakdown.FinalHitChance $ ") and was clamped to avoid confusing the UI (@btopp).", bDebugLog, 'XCom_HitRolls');
+		m_ShotBreakdown.FinalHitChance = 0;
+	}
+}

--- a/XComGame/Classes/X2AbilityToHitCalc.uc
+++ b/XComGame/Classes/X2AbilityToHitCalc.uc
@@ -12,7 +12,7 @@ class X2AbilityToHitCalc extends Object
 
 var() array<ShotModifierInfo> HitModifiers;       // Configured in the ability template to provide always-on modifiers.
 
-// Start Issue #555
+// Begin HELIOS Issue #45 (WOTC CHL #555)
 //
 // Mods can add their own matching functions to this array within
 // OnPostTemplatesCreated() in order to modify or override the default
@@ -24,7 +24,7 @@ var() array<ShotModifierInfo> HitModifiers;       // Configured in the ability t
 var array< delegate<OverrideFinalHitChance> > OverrideFinalHitChanceFns;
 
 delegate bool OverrideFinalHitChance(X2AbilityToHitCalc AbilityToHitCalc, out ShotBreakdown ShotBreakdown);
-// End Issue #555
+// End HELIOS Issue #45 (WOTC CHL #555)
 
 function RollForAbilityHit(XComGameState_Ability kAbility, AvailableTarget kTarget, out AbilityResultContext ResultContext);
 protected function int GetHitChance(XComGameState_Ability kAbility, AvailableTarget kTarget, optional out ShotBreakdown m_ShotBreakdown, optional bool bDebugLog=false);
@@ -79,12 +79,12 @@ protected function FinalizeHitChance(out ShotBreakdown m_ShotBreakdown, bool bDe
 	local int LuckyGraze;
 	local int MissToLuckyGraze;
 
-    // Vars for Issue #555
+    // Vars for HELIOS Issue #45 (WOTC CHL #555)
 	local bool OverrideHitChanceCalc;
 	local delegate<OverrideFinalHitChance> OverrideFn;
-	// End Issue #555
+	// End HELIOS Issue #45 (WOTC CHL #555)
 
-    // Start Issue #555
+    // Begin HELIOS Issue #45 (WOTC CHL #555)
     OverrideHitChanceCalc = false;
 	foreach OverrideFinalHitChanceFns(OverrideFn)
 	{
@@ -97,7 +97,7 @@ protected function FinalizeHitChance(out ShotBreakdown m_ShotBreakdown, bool bDe
 	{
 		return;
 	}
-    // End Issue #555
+	// End HELIOS Issue #45 (WOTC CHL #555)
 
 	`log("==" $ GetFuncName() $ "==\n", bDebugLog, 'XCom_HitRolls');
 	`log("Starting values...", bDebugLog, 'XCom_HitRolls');

--- a/XComGame/Classes/X2AbilityToHitCalc.uc
+++ b/XComGame/Classes/X2AbilityToHitCalc.uc
@@ -23,6 +23,8 @@ var() array<ShotModifierInfo> HitModifiers;       // Configured in the ability t
 // default logic, or false if the logic should execute.
 var array< delegate<OverrideFinalHitChance> > OverrideFinalHitChanceFns;
 
+delegate bool OverrideFinalHitChance(X2AbilityToHitCalc AbilityToHitCalc, out ShotBreakdown ShotBreakdown);
+// End Issue #555
 
 function RollForAbilityHit(XComGameState_Ability kAbility, AvailableTarget kTarget, out AbilityResultContext ResultContext);
 protected function int GetHitChance(XComGameState_Ability kAbility, AvailableTarget kTarget, optional out ShotBreakdown m_ShotBreakdown, optional bool bDebugLog=false);


### PR DESCRIPTION
This change adds an 'OverrideFinalHitChance' event that allows mods to override the shot breakdown for abilities. This is necessary to implement the graze band for LW2, but could be used by others as well.

This Imports Issue #555 and PR #556 From X2 Highlander